### PR TITLE
Багфикс. Некорректный ответ сервера приводил к ошибке на клиенте при добавлении события.

### DIFF
--- a/core/components/mycalendar/model/mycalendar/mycalendar.class.php
+++ b/core/components/mycalendar/model/mycalendar/mycalendar.class.php
@@ -328,7 +328,7 @@ class myCalendar {
         $event_arr = $event->toArray();
         $properties = array();
         if (!empty($event_arr['properties'])) $properties = $this->modx->fromJSON($event_arr['properties']);
-        $output = '';
+        $output = array();
         foreach ($this->fields as $field) {
             if ($field == 'id') {
                 $output['id'] = $event->get('id');


### PR DESCRIPTION
Переменная инициализировалась строкой, использовалась как массив. Это приводило к ошибке на клиенте, т.к. возвращалась строка из одной буквы вместо JSON-объекта. Ошибка выражалась в том, что не отрабатывал рендеринг календаря при добавлении события (скрипт падал в методе `normalizeEventTimes()` файла `fullcalendar.js`, т.к. `eventProps.start` был `undefined`), изменения отображались только при перезагрузке страницы.